### PR TITLE
Add crown-marketplace app

### DIFF
--- a/terraform/build/crown-marketplace/main.tf
+++ b/terraform/build/crown-marketplace/main.tf
@@ -1,0 +1,30 @@
+module "component" {
+    # source = "git::https://github.com/Crown-Commercial-Service/CMpDevEnvironment.git//terraform/modules/component"
+    source = "../../modules/component"
+
+    type = "app"
+    prefix = "ccs"
+    name = "crown-marketplace"
+    build_type = "ruby"
+    github_owner = "Crown-Commercial-Service"
+    github_repo = "crown-marketplace"
+    github_branch = "master"
+    github_token_alias = "ccs-build_github_token"
+    cluster_name = "CCSDEV_app_cluster"
+    task_count = 1
+    environment = [
+      {
+        name = "CCS_FEATURE_EG1",
+        value = "off"
+      },
+      {
+        name = "RAILS_ENV",
+        value = "production"
+      },
+      {
+        name = "RAILS_SERVE_STATIC_FILES",
+        value = "true"
+      }
+    ]
+    port = "80"
+}


### PR DESCRIPTION
Note that we still need to work out how to set the `SECRET_KEY_BASE` and
`GOOGLE_GEOCODING_API_KEY` secrets in the container before we actually
deploy the app.