### PR TITLE
(chore) Amend Cognito logout link to redirect users back to login page

### DIFF
--- a/terraform/build/crown-marketplace/main.tf
+++ b/terraform/build/crown-marketplace/main.tf
@@ -17,6 +17,7 @@ module "component" {
     enable_tests = true
     enable_cognito_support = true
     cognito_login_callback = "auth/cognito/callback"
+    cognito_logout_callback = "supply-teachers/gateway"
     environment = [
       {
         name = "RAILS_ENV",


### PR DESCRIPTION
Trello: https://trello.com/c/nTwYhW9n/909-exception-when-signing-out-via-cognito

The issue: On logout via Cognito, the user was being redirected back to '/' on the relevant environment. This page does not contain any information about the supply teachers framework, so the user could easily get lost.

This change updates the logout url to be `<service-url>/supply-teachers/gateway`, so on cmpdev it should resolve to `https://cmp.cmpdev.crowncommercial.gov.uk/supply-teachers/gateway` and on production, `https://marketplace.service.crowncommercial.gov.uk/supply-teachers/gateway`

Note that this URL will need to be updated again if other frameworks come into play.