### PR TITLE
Apply service changelog updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Generated lambda zip
 /terraform/infrastructure/*.zip
+
+# Ignore Eclipse files
+.project
+.classfile

--- a/terraform/infrastructure/README.md
+++ b/terraform/infrastructure/README.md
@@ -163,6 +163,10 @@ variable "default_db_storage" {
   default = 20
 }
 
+variable "default_db_apply_immediately" {
+  default = true
+}
+
 variable "default_db_name" {
   default = "cmpdefault"
 }

--- a/terraform/infrastructure/ccsdev_database.tf
+++ b/terraform/infrastructure/ccsdev_database.tf
@@ -129,6 +129,7 @@ resource "aws_db_instance" "ccsdev_default_db" {
 
   identifier                = "ccsdev-db"
   allocated_storage         = "${var.default_db_storage}"
+  apply_immediately         = "${var.default_db_apply_immediately}"
   storage_type              = "gp2"
   engine                    = "postgres"
   engine_version            = "11.2"

--- a/terraform/infrastructure/variables.tf
+++ b/terraform/infrastructure/variables.tf
@@ -27,6 +27,7 @@ variable ccs_cognito_groups {
   default = {
     "at_access" = "Apprenticeships user access",
     "buyer" = "Buyer user access",
+    "supplier" = "Supplier user access",
     "ccs_employee" = "CCS Employee user access",
     "fm_access" = "Facilities Management user access",
     "ls_access" = "Legal Services user access",

--- a/terraform/infrastructure/variables.tf
+++ b/terraform/infrastructure/variables.tf
@@ -132,7 +132,11 @@ variable "default_db_instance_class" {
 }
 
 variable "default_db_storage" {
-  default = 40
+  default = 100
+}
+
+variable "default_db_apply_immediately" {
+  default = false
 }
 
 variable "default_db_type" {

--- a/terraform/security/ccsdev_mfa_iam.tf
+++ b/terraform/security/ccsdev_mfa_iam.tf
@@ -1,0 +1,64 @@
+##############################################################
+#
+# CCSDEV MFA IAM Configuration
+#
+# This script defines user/group related MFA IAM assets
+#
+#   Polices
+#     CCS_manageown_mfa_device
+#   Roles
+#   Groups
+#     CCS_MFA_ManageOwnDevice
+#
+#   Users?
+#
+##############################################################
+
+resource "aws_iam_group" "CCS_MFA_ManageOwnDevice" {
+  name = "CCS_MFA_ManageOwnDevice"
+}
+
+resource "aws_iam_policy" "CCS_manageown_mfa_device" {
+  name   = "CCS_manageown_mfa_device"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.CCS_manageown_mfa_device.json}"
+}
+
+data "aws_iam_policy_document" "CCS_manageown_mfa_device" {
+  statement {
+    sid = "AllowManageOwnVirtualMFADevice"
+
+    effect = "Allow"
+
+    actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:DeleteVirtualMFADevice",
+    ]
+
+    resources = [
+      "arn:aws:iam::*:mfa/&{aws:username}",
+    ]
+  }
+
+  statement {
+    sid = "AllowManageOwnUserMFA"
+
+    effect = "Allow"
+
+    actions = [
+      "iam:DeactivateMFADevice",
+      "iam:EnableMFADevice",
+      "iam:ListMFADevices",
+      "iam:ResyncMFADevice",
+    ]
+
+    resources = [
+      "arn:aws:iam::*:user/&{aws:username}",
+    ]
+  }
+}
+
+resource "aws_iam_group_policy_attachment" "CCS_manageown_mfa_device" {
+  group      = "${aws_iam_group.CCS_MFA_ManageOwnDevice.name}"
+  policy_arn = "${aws_iam_policy.CCS_manageown_mfa_device.arn}"
+}


### PR DESCRIPTION
Applied some of the changes made to the environment as described in the AWS Service Change Log.

- Increased default database size to 100Gb and added apply-immediately 
- Added "supplier" to Cognito groups
- Added support for MFA manage own device IAM groups/roles/permissions