### PR TITLE
Code split - Sept 2020 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 # Generated lambda zip
 /terraform/infrastructure/*.zip
 
+# Scratch directory used for playing around
+/terraform/scratch
+
 # Ignore Eclipse files
 .project
 .classfile

--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ Environment variables can also be used to pass feature switches to containers. T
 
 The Application/API data S3 bucket is passed in the environment variable: `CCS_APP_API_DATA_BUCKET`.
 
+The assets bucket is passed in the environment variable: `ASSETS_BUCKET`.
+
 `CCS_FEATURE_EG1=on`
 
 ### Parameter lifecycle, changes and overriding

--- a/terraform/build/crown-marketplace-legacy/main.tf
+++ b/terraform/build/crown-marketplace-legacy/main.tf
@@ -15,7 +15,10 @@ module "component" {
     register_dns_record = true
     health_check_path = "/legal-services"
     hostname = "cmp"
-    routing_priority_offset = 100
+    # note as part of sept2020 changes and a swapping priorities of crown-marketplace and
+    # crown-marketplace-legacy over cannot simply swap numbers as when run terrafrom it
+    # can't swap as prioriy in use; instead increase both by one so swapping to a new number
+    routing_priority_offset = 101
     build_type = "custom"
     build_image = "ccs/ruby"
     github_owner = "Crown-Commercial-Service"

--- a/terraform/build/crown-marketplace-legacy/main.tf
+++ b/terraform/build/crown-marketplace-legacy/main.tf
@@ -15,7 +15,7 @@ module "component" {
     register_dns_record = true
     health_check_path = "/legal-services"
     hostname = "cmp"
-    routing_priority_offset = 200
+    routing_priority_offset = 100
     build_type = "custom"
     build_image = "ccs/ruby"
     github_owner = "Crown-Commercial-Service"

--- a/terraform/build/crown-marketplace-legacy/main.tf
+++ b/terraform/build/crown-marketplace-legacy/main.tf
@@ -11,6 +11,9 @@ module "component" {
     type = "app"
     prefix = "ccs"
     name = "cmp-legacy"
+    path_patterns = ["/management-consultancy*", "/supply-teachers*", "/legal-services*"]
+    register_dns_record = true
+    health_check_path = "/legal-services"
     hostname = "cmp"
     routing_priority_offset = 200
     build_type = "custom"

--- a/terraform/build/crown-marketplace-legacy/main.tf
+++ b/terraform/build/crown-marketplace-legacy/main.tf
@@ -13,7 +13,6 @@ module "component" {
     name = "cmp-legacy"
     path_patterns = ["/management-consultancy*", "/supply-teachers*", "/legal-services*"]
     register_dns_record = true
-    health_check_path = "/legal-services"
     hostname = "cmp"
     # note as part of sept2020 changes and a swapping priorities of crown-marketplace and
     # crown-marketplace-legacy over cannot simply swap numbers as when run terrafrom it

--- a/terraform/build/crown-marketplace/main.tf
+++ b/terraform/build/crown-marketplace/main.tf
@@ -9,7 +9,8 @@ module "component" {
     type = "app"
     prefix = "ccs"
     name = "cmp"
-    path_pattern = "/facilities-management"
+    path_patterns = []
+    register_dns_record = false
     health_check_path = "/facilities-management"
     routing_priority_offset = 100
     build_type = "custom"

--- a/terraform/build/crown-marketplace/main.tf
+++ b/terraform/build/crown-marketplace/main.tf
@@ -12,7 +12,7 @@ module "component" {
     path_patterns = []
     register_dns_record = false
     health_check_path = "/facilities-management"
-    routing_priority_offset = 100
+    routing_priority_offset = 200
     build_type = "custom"
     build_image = "ccs/ruby"
     github_owner = "Crown-Commercial-Service"

--- a/terraform/build/crown-marketplace/main.tf
+++ b/terraform/build/crown-marketplace/main.tf
@@ -12,7 +12,7 @@ module "component" {
     path_patterns = []
     register_dns_record = false
     health_check_path = "/facilities-management"
-    routing_priority_offset = 200
+    routing_priority_offset = 201
     build_type = "custom"
     build_image = "ccs/ruby"
     github_owner = "Crown-Commercial-Service"

--- a/terraform/infrastructure/README.md
+++ b/terraform/infrastructure/README.md
@@ -77,6 +77,12 @@ An S3 bucket is also created for use by application and API containers. The cont
 
 The name of the bucket is passed to containers in the environment variable: `CCS_APP_API_DATA_BUCKET`.
 
+An S3 bucket is created with public access for storing assets to be served be the web application.
+
+```<account number>.assets```
+
+The name of the bucket is passed to containers in the environment variable: `ASSETS_BUCKET`.
+
 ---
 
 ## EC2 Instances ##

--- a/terraform/infrastructure/ccsdev_s3.tf
+++ b/terraform/infrastructure/ccsdev_s3.tf
@@ -70,7 +70,7 @@ resource "aws_s3_bucket" "logs" {
 }
 
 ##############################################################
-# Appliaction/API Storage
+# Application/API Storage
 ##############################################################
 resource "aws_s3_bucket" "app-api-data-bucket" {
   bucket = "${local.app_api_bucket_name}"
@@ -82,6 +82,59 @@ resource "aws_s3_bucket" "app-api-data-bucket" {
     CCSEnvironment = "${var.environment_name}"
   }
 }
+
+##############################################################
+# Asset Storage
+##############################################################
+resource "aws_iam_policy" "CCSDEV_assets_bucket_policy" {
+  name   = "CCSDEV_assets_bucket_policy"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.CCSDEV_assets_bucket_policy_doc.json}"
+}
+
+resource "aws_iam_group_policy_attachment" "dev-api-assets-bucket-policy-attachment" {
+  group      = "CCS_Developer_API_Access"
+  policy_arn = "${aws_iam_policy.CCSDEV_assets_bucket_policy.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "task-role-assets-bucket-policy-attachment" {
+  role       = "CCSDEV-task-role"
+  policy_arn = "${aws_iam_policy.CCSDEV_assets_bucket_policy.arn}"
+}
+
+data "aws_iam_policy_document" "CCSDEV_assets_bucket_policy_doc" {
+
+  statement {
+
+    effect = "Allow",
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.assets-bucket.arn}/*",
+      "${aws_s3_bucket.assets-bucket.arn}"
+    ]
+  }
+}
+
+resource "aws_s3_bucket" "assets-bucket" {
+  bucket = "${local.assets_bucket_name}"
+  
+   acl    = "public-read"
+  #grant {
+  #  type        = "Group"
+  #  uri         = "http://acs.amazonaws.com/groups/global/AllUsers"
+  #  permissions = ["READ_ACP"]
+  #}
+
+  tags {
+    Name = "CCSDEV Application/assets bucket"
+    CCSRole = "Infrastructure"
+    CCSEnvironment = "${var.environment_name}"
+  }
+}
+
 
 ##############################################################
 # Add custom policy to CCS_Developer_API_Access group and

--- a/terraform/infrastructure/config.tf
+++ b/terraform/infrastructure/config.tf
@@ -209,3 +209,16 @@ resource "aws_ssm_parameter" "config_redis_port" {
     CCSEnvironment = "${var.environment_name}"
   }
 }
+
+resource "aws_ssm_parameter" "config_s3_assets_bucket" {
+  name  = "/${var.environment_name}/config/assets_bucket"
+  description  = "S3 bucket used for assets"
+  type  = "SecureString"
+  value = "${local.assets_bucket_name}"
+
+  tags {
+    Name = "Parameter Store: S3 bucket used for assets data"
+    CCSRole = "Infrastructure"
+    CCSEnvironment = "${var.environment_name}"
+  }
+}

--- a/terraform/infrastructure/variables.tf
+++ b/terraform/infrastructure/variables.tf
@@ -248,4 +248,5 @@ locals {
   artifact_bucket_name = "ccs.${data.aws_caller_identity.current.account_id}.build-artifacts"
   log_bucket_name = "ccs.${data.aws_caller_identity.current.account_id}.${lower(var.environment_name)}.logs"
   app_api_bucket_name = "ccs.${data.aws_caller_identity.current.account_id}.${lower(var.environment_name)}.app-api-data"
+  assets_bucket_name = "${data.aws_caller_identity.current.account_id}.assets"
 }

--- a/terraform/modules/component/main.tf
+++ b/terraform/modules/component/main.tf
@@ -112,7 +112,7 @@ module "build" {
   enable_tests = "${var.enable_tests}"
   service_role_arn = "${data.aws_iam_role.codebuild_service_role.arn}"
   vpc_id = "${data.aws_vpc.CCSDEV-Services.id}"
-  subnet_ids = ["${data.aws_subnet.CCSDEV-AZ-a-Private-1.id}"]
+  subnet_ids = ["${data.aws_subnet.CCSDEV-AZ-a-Private-1.id}", "${data.aws_subnet.CCSDEV-AZ-b-Private-1.id}", "${data.aws_subnet.CCSDEV-AZ-c-Private-1.id}"]
   security_group_ids = ["${data.aws_security_group.vpc-CCSDEV-internal.id}"]
 }
 

--- a/terraform/modules/component/main.tf
+++ b/terraform/modules/component/main.tf
@@ -87,6 +87,10 @@ data "aws_ssm_parameter" "config_s3_app_api_data_bucket" {
   name = "/${var.environment_name}/config/app_api_data_bucket"
 }
 
+data "aws_ssm_parameter" "config_s3_assets_bucket" {
+  name = "/${var.environment_name}/config/assets_bucket"
+}
+
 ##############################################################
 # Subdomain
 ##############################################################
@@ -203,6 +207,11 @@ locals {
       {
         name = "CCS_APP_API_DATA_BUCKET",
         value = "${data.aws_ssm_parameter.config_s3_app_api_data_bucket.value}"
+      },
+      # name is not consistent because this is what devs had already coded
+      {
+        name = "ASSETS_BUCKET",
+        value = "${data.aws_ssm_parameter.config_s3_assets_bucket.value}"
       }
     ]
 }

--- a/terraform/modules/component/main.tf
+++ b/terraform/modules/component/main.tf
@@ -287,7 +287,8 @@ module "routing" {
   protocol  = "${local.config_protocol}"
   hostname  = "${local.config_hostname}"
   port      = "${var.port}"
-  path_pattern = "${var.path_pattern}"
+  path_patterns = "${var.path_patterns}"
+  register_dns_record = "${var.register_dns_record}"
   health_check_path = "${var.health_check_path}"
   providers = {
     aws = "aws"

--- a/terraform/modules/component/variables.tf
+++ b/terraform/modules/component/variables.tf
@@ -219,6 +219,18 @@ data "aws_subnet" "CCSDEV-AZ-a-Private-1" {
   }
 }
 
+data "aws_subnet" "CCSDEV-AZ-b-Private-1" {
+  tags {
+    "Name" = "CCSDEV-AZ-b-Private-1"
+  }
+}
+
+data "aws_subnet" "CCSDEV-AZ-c-Private-1" {
+  tags {
+    "Name" = "CCSDEV-AZ-c-Private-1"
+  }
+}
+
 data "aws_security_group" "vpc-CCSDEV-internal" {
   tags {
     "Name" = "CCSDEV-internal-${var.type}"

--- a/terraform/modules/component/variables.tf
+++ b/terraform/modules/component/variables.tf
@@ -33,9 +33,19 @@ variable hostname {
 ##############################################################
 # Path (for routing purposes)
 ##############################################################
-variable path_pattern {
-    type = "string"
-    default = ""
+variable path_patterns {
+    type = "list"
+    default = []
+}
+
+##############################################################
+# Flag to register the DNS record, assumes it always does and
+# can then be disabled if another build process is hanlding
+# the registration
+##############################################################
+variable register_dns_record {
+  type = "string"
+  default = true
 }
 
 ##############################################################

--- a/terraform/modules/routing/variables.tf
+++ b/terraform/modules/routing/variables.tf
@@ -31,9 +31,19 @@ variable hostname {
 ##############################################################
 # Path pattern to use for routing
 ##############################################################
-variable path_pattern {
-    type = "string"
-    default = ""
+variable path_patterns {
+    type = "list"
+    default = []
+}
+
+##############################################################
+# Flag to register the DNS record, assumes it always does and
+# can then be disabled if another build process is hanlding
+# the registration
+##############################################################
+variable register_dns_record {
+  type = "string"
+  default = true
 }
 
 ##############################################################

--- a/terraform/ssm-config/main.tf
+++ b/terraform/ssm-config/main.tf
@@ -253,3 +253,9 @@ resource "aws_ssm_parameter" "cmplegacy_supplier_details_data_key" {
 	type = "SecureString"
 	value = "facilities_management/data/static/RM3830_Suppliers_Details_for_dev_and_test.xlsx"
 }
+
+resource "aws_ssm_parameter" "app_run_precompile_assets" {
+	name = "/Environment/global/APP_RUN_PRECOMPILE_ASSETS"
+	type = "SecureString"
+	value = "TRUE"
+}


### PR DESCRIPTION
Have added the S3 bucket with associated policies as described by Will. At the moment have used "public-read" ACL and not List ACL permission (that is working too, but commented out for now). When we know which is required we can choose the appropriate one.

Added availability zones a, b and c for build pipelines.

For the two parameters - they are handled differently as they relate to different things. 

ASSETS_BUCKET: As the assets bucket is created by the infrastructure terraform it also creates an SSM Parameter for the bucket name following the naming convention already used by the terraform

Have (arbitrarily) assumed APP_RUN_PRECOMPILE_ASSETS is to managed as an SSM Parameter value. Have updated the "ssm-config" module in the git project. On CCS environments this will need to be managed using Ansible like the other parameters of this type.

Added routing rules. Changed routing module to accept a list of path patterns instead of a single path pattern. Swapped crown-marketplace and crown-marketplace-legacy logic and priorities over. Had to add an offset (+1) to the priority otherwise got a conflict as when applying the first change priority conflicted with the existing priority of the other rule. DNS registration is now explicit and not implied from existence of path patterns. Need to double check what health check URIs should be used for the different instances - have left facilities-management as is (as this is how sandbox is configured) and used "/" for the other, again to match sandbox.
