### PR TITLE
Sandbox Instance Size Reduction

### DIFF
--- a/terraform/infrastructure/variables.tf
+++ b/terraform/infrastructure/variables.tf
@@ -82,7 +82,7 @@ variable "app_cluster_ami" {
 }
 
 variable "app_cluster_instance_class" {
-  default = "m4.large"
+  default = "t2.large"
 }
 
 variable "app_cluster_instance_count" {
@@ -106,7 +106,7 @@ variable "api_cluster_ami" {
 }
 
 variable "api_cluster_instance_class" {
-  default = "m4.large"
+  default = "t2.large"
 }
 
 variable "api_cluster_instance_count" {


### PR DESCRIPTION
Changing ec2 instance sizes from m4.large to t2.large for sandbox