### PR TITLE
Sandbox: Bump DB Instance Engine version & Elasticache Instance Class

### DIFF
--- a/terraform/infrastructure/ccsdev_database.tf
+++ b/terraform/infrastructure/ccsdev_database.tf
@@ -132,7 +132,7 @@ resource "aws_db_instance" "ccsdev_default_db" {
   apply_immediately         = "${var.default_db_apply_immediately}"
   storage_type              = "gp2"
   engine                    = "postgres"
-  engine_version            = "11.2"
+  engine_version            = "11.8"
   instance_class            = "${var.default_db_instance_class}"
   name                      = "${var.default_db_name}"
   username                  = "${var.default_db_username}"

--- a/terraform/infrastructure/variables.tf
+++ b/terraform/infrastructure/variables.tf
@@ -192,7 +192,7 @@ variable "create_elasticache_redis" {
 }
 
 variable "elasticache_instance_class" {
-  default = "cache.t2.small"
+  default = "cache.t2.medium"
 }
 
 ##############################################################


### PR DESCRIPTION
- Bump Elasticache instance class size to t2.medium
- Bump DB Instance Engine version to 11.8