### PR TITLE
Tech ops development tls ithc change

### DIFF
--- a/terraform/infrastructure/api_cluster.tf
+++ b/terraform/infrastructure/api_cluster.tf
@@ -85,7 +85,7 @@ resource "aws_alb_listener" "CCSDEV_api_cluster_alb_listener_https" {
   load_balancer_arn = "${aws_alb.CCSDEV_api_cluster_alb.arn}"
   port              = "${var.https_port}"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2015-05"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
   certificate_arn   = "${aws_acm_certificate.private_cluster_wildcard_certificate.arn}"
 
   default_action {

--- a/terraform/infrastructure/app_cluster.tf
+++ b/terraform/infrastructure/app_cluster.tf
@@ -89,7 +89,7 @@ resource "aws_alb_listener" "CCSDEV_app_cluster_alb_listener_https" {
   load_balancer_arn = "${aws_alb.CCSDEV_app_cluster_alb.arn}"
   port              = "${var.https_port}"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-FS-2018-06"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-2019-08"
   certificate_arn   = "${aws_acm_certificate.public_cluster_wildcard_certificate.arn}"
 
   default_action {


### PR DESCRIPTION
TLS change, turning off TLS 1.0/1 and CBC ciphers as per ticket https://crowncommercial.zendesk.com/agent/tickets/17600 in response to ITHC.