### PR TITLE
CLE-3: Implement ITHC Terraform Code (Development)

### DIFF
--- a/terraform/access-logs/main.tf
+++ b/terraform/access-logs/main.tf
@@ -1,0 +1,84 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_canonical_user_id" "current_user" {}
+
+locals {
+  s3_logging_bucket_name = "ccs.${data.aws_caller_identity.current.account_id}.s3.access-logs"
+}
+
+resource "aws_s3_bucket" "s3_logging_bucket" {
+  bucket = "${local.s3_logging_bucket_name}"
+
+  grant {
+    permissions = ["READ_ACP", "WRITE"]
+    type        = "Group"
+    uri         = "http://acs.amazonaws.com/groups/s3/LogDelivery"
+  }
+
+  grant {
+    id          = "${data.aws_canonical_user_id.current_user.id}"
+    type        = "CanonicalUser"
+    permissions = ["READ_ACP", "WRITE_ACP", "WRITE", "READ"]
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  tags = {
+    CCSEnvironment = "Sandbox"
+    CCSRole        = "Infrastructure"
+    Name           = "CCS Sandbox Access Logs Bucket"
+  }
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "s3_logging_bucket_public_access_block" {
+  bucket = "${aws_s3_bucket.s3_logging_bucket.id}"
+
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+
+data "aws_iam_policy_document" "secure_transport_policy" {
+  statement {
+    effect = "Deny"
+
+    principals {
+      identifiers = ["*"]
+      type = "*"
+    }
+
+    actions = [
+      "s3:*",
+    ]
+
+    condition {
+      test = "Bool"
+
+      values = [
+        "false",
+      ]
+
+      variable = "aws:SecureTransport"
+    }
+
+    resources = [
+      "${aws_s3_bucket.s3_logging_bucket.arn}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = "${aws_s3_bucket.s3_logging_bucket.bucket}"
+  policy = "${data.aws_iam_policy_document.secure_transport_policy.json}"
+}

--- a/terraform/access-logs/main.tf
+++ b/terraform/access-logs/main.tf
@@ -30,9 +30,9 @@ resource "aws_s3_bucket" "s3_logging_bucket" {
   }
 
   tags = {
-    CCSEnvironment = "Sandbox"
+    CCSEnvironment = "Development"
     CCSRole        = "Infrastructure"
-    Name           = "CCS Sandbox Access Logs Bucket"
+    Name           = "CCS Development Access Logs Bucket"
   }
 
   versioning {
@@ -78,7 +78,7 @@ data "aws_iam_policy_document" "secure_transport_policy" {
   }
 }
 
-resource "aws_s3_bucket_policy" "this" {
+resource "aws_s3_bucket_policy" "s3_logging_bucket_policy" {
   bucket = "${aws_s3_bucket.s3_logging_bucket.bucket}"
   policy = "${data.aws_iam_policy_document.secure_transport_policy.json}"
 }

--- a/terraform/access-logs/providers.tf
+++ b/terraform/access-logs/providers.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  version = "~> 2.70"
+  region  = "${var.region}"
+}
+
+provider "local" {
+  version = "~> 1.4"
+}
+
+provider "template" {
+  version = "~> 2.1"
+}

--- a/terraform/access-logs/variables.tf
+++ b/terraform/access-logs/variables.tf
@@ -1,0 +1,7 @@
+variable "environment" {
+  default = "development"
+}
+
+variable "region" {
+  default = "eu-west-2"
+}

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -101,6 +101,15 @@ resource "aws_dynamodb_table" "terraform_state_lock" {
     ]
 }
 
+module "access_logs_backend" {
+    source    = "./backend"
+
+    bucket    = "${local.bucket_name}"
+    component = "access-logs"
+    region    = "${var.region}"
+    path      = "${path.module}"
+}
+
 module "security_backend" {
     source    = "./backend"
 

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -4,8 +4,13 @@ terraform {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_s3_bucket" "s3_logging_bucket" {
+    bucket = "${local.s3_logging_bucket_name}"
+}
+
 locals {
     bucket_name = "ccs.${data.aws_caller_identity.current.account_id}.tfstate"
+    s3_logging_bucket_name = "ccs.${data.aws_caller_identity.current.account_id}.s3.access-logs"
 }
 
 resource "aws_iam_user_policy_attachment" "bootstrap-dynamodb-attach" {
@@ -30,6 +35,53 @@ resource "aws_s3_bucket" "terraform_state" {
         "bucket",
         ]
   }
+
+  logging {
+    target_bucket = "${data.aws_s3_bucket.s3_logging_bucket.id}"
+    target_prefix = "Logs/"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+        apply_server_side_encryption_by_default {
+            sse_algorithm = "AES256"
+        }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "terraform_state_s3_policy" {
+    statement {
+        effect = "Deny"
+
+        principals {
+            identifiers = ["*"]
+            type = "*"
+        }
+
+        actions = [
+            "s3:*",
+        ]
+
+        condition {
+            test = "Bool"
+
+            values = [
+                "false",
+            ]
+
+            variable = "aws:SecureTransport"
+        }
+
+        resources = [
+            "${aws_s3_bucket.terraform_state.arn}/*",
+        ]
+    }
+}
+
+resource "aws_s3_bucket_policy" "terraform_state" {
+    bucket = "${aws_s3_bucket.terraform_state.bucket}"
+    policy = "${data.aws_iam_policy_document.terraform_state_s3_policy.json}"
 }
 
 resource "aws_dynamodb_table" "terraform_state_lock" {

--- a/terraform/infrastructure/ccsdev_s3.tf
+++ b/terraform/infrastructure/ccsdev_s3.tf
@@ -92,6 +92,31 @@ data "aws_iam_policy_document" "log_policy_document" {
 
     resources = ["arn:aws:s3:::${local.log_bucket_name}/*"]
   }
+
+  statement {
+    effect = "Deny"
+
+    principals {
+      identifiers = ["*"]
+      type = "*"
+    }
+
+    actions = [
+      "s3:*",
+    ]
+
+    condition {
+      test = "Bool"
+
+      values = [
+        "false",
+      ]
+
+      variable = "aws:SecureTransport"
+    }
+
+    resources = ["arn:aws:s3:::${local.log_bucket_name}/*"]
+  }
 }
 
 resource "aws_s3_bucket" "logs" {
@@ -112,6 +137,19 @@ resource "aws_s3_bucket" "logs" {
 
     expiration {
       days = 1
+    }
+  }
+
+  logging {
+    target_bucket = "${data.aws_s3_bucket.s3_logging_bucket.id}"
+    target_prefix = "Logs/"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
     }
   }
 

--- a/terraform/infrastructure/ccsdev_s3.tf
+++ b/terraform/infrastructure/ccsdev_s3.tf
@@ -131,11 +131,62 @@ resource "aws_s3_bucket" "app-api-data-bucket" {
   bucket = "${local.app_api_bucket_name}"
   acl    = "private"
 
+  logging {
+    target_bucket = "${data.aws_s3_bucket.s3_logging_bucket.id}"
+    target_prefix = "Logs/"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   tags {
     Name = "CCSDEV Application/API data bucket"
     CCSRole = "Infrastructure"
     CCSEnvironment = "${var.environment_name}"
   }
+
+  versioning {
+    enabled = true
+  }
+}
+
+data "aws_iam_policy_document" "app_api_data_policy" {
+  statement {
+    effect = "Deny"
+
+    principals {
+      identifiers = ["*"]
+      type = "*"
+    }
+
+    actions = [
+      "s3:*",
+    ]
+
+    condition {
+      test = "Bool"
+
+      values = [
+        "false",
+      ]
+
+      variable = "aws:SecureTransport"
+    }
+
+    resources = [
+      "${aws_s3_bucket.app-api-data-bucket.arn}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "attach_secure_transport_policy_to_app_api_data_s3" {
+  bucket = "${aws_s3_bucket.app-api-data-bucket.bucket}"
+  policy = "${data.aws_iam_policy_document.app_api_data_policy.json}"
 }
 
 ##############################################################

--- a/terraform/infrastructure/ccsdev_s3.tf
+++ b/terraform/infrastructure/ccsdev_s3.tf
@@ -1,6 +1,10 @@
 ##############################################################
 # Artifact Storage
 ##############################################################
+data "aws_s3_bucket" "s3_logging_bucket" {
+  bucket = "${local.s3_logging_bucket_name}"
+}
+
 resource "aws_s3_bucket" "build-artifacts" {
   bucket = "${local.artifact_bucket_name}"
   acl    = "private"
@@ -13,11 +17,62 @@ resource "aws_s3_bucket" "build-artifacts" {
     }
   }
 
+  logging {
+    target_bucket = "${data.aws_s3_bucket.s3_logging_bucket.id}"
+    target_prefix = "Logs/"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   tags {
     Name = "CCSDEV Build Artifacts bucket"
     CCSRole = "Infrastructure"
     CCSEnvironment = "${var.environment_name}"
   }
+
+  versioning {
+    enabled = true
+  }
+}
+
+data "aws_iam_policy_document" "secure_transport_policy" {
+  statement {
+    effect = "Deny"
+
+    principals {
+      identifiers = ["*"]
+      type = "*"
+    }
+
+    actions = [
+      "s3:*",
+    ]
+
+    condition {
+      test = "Bool"
+
+      values = [
+        "false",
+      ]
+
+      variable = "aws:SecureTransport"
+    }
+
+    resources = [
+      "${aws_s3_bucket.build-artifacts.arn}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "attach_secure_transport_policy_to_build_artifacts_s3" {
+  bucket = "${aws_s3_bucket.build-artifacts.bucket}"
+  policy = "${data.aws_iam_policy_document.secure_transport_policy.json}"
 }
 
 ##############################################################

--- a/terraform/infrastructure/ccsdev_s3.tf
+++ b/terraform/infrastructure/ccsdev_s3.tf
@@ -41,7 +41,7 @@ resource "aws_s3_bucket" "build-artifacts" {
   }
 }
 
-data "aws_iam_policy_document" "secure_transport_policy" {
+data "aws_iam_policy_document" "build_artifacts_policy" {
   statement {
     effect = "Deny"
 
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "secure_transport_policy" {
 
 resource "aws_s3_bucket_policy" "attach_secure_transport_policy_to_build_artifacts_s3" {
   bucket = "${aws_s3_bucket.build-artifacts.bucket}"
-  policy = "${data.aws_iam_policy_document.secure_transport_policy.json}"
+  policy = "${data.aws_iam_policy_document.build_artifacts_policy.json}"
 }
 
 ##############################################################

--- a/terraform/infrastructure/ccsdev_s3.tf
+++ b/terraform/infrastructure/ccsdev_s3.tf
@@ -235,20 +235,70 @@ data "aws_iam_policy_document" "CCSDEV_assets_bucket_policy_doc" {
 resource "aws_s3_bucket" "assets-bucket" {
   bucket = "${local.assets_bucket_name}"
   
-   acl    = "public-read"
+  acl    = "public-read"
   #grant {
   #  type        = "Group"
   #  uri         = "http://acs.amazonaws.com/groups/global/AllUsers"
   #  permissions = ["READ_ACP"]
   #}
 
+  logging {
+    target_bucket = "${data.aws_s3_bucket.s3_logging_bucket.id}"
+    target_prefix = "Logs/"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   tags {
     Name = "CCSDEV Application/assets bucket"
     CCSRole = "Infrastructure"
     CCSEnvironment = "${var.environment_name}"
   }
+
+  versioning {
+    enabled = true
+  }
 }
 
+data "aws_iam_policy_document" "assets_bucket_policy" {
+  statement {
+    effect = "Deny"
+
+    principals {
+      identifiers = ["*"]
+      type = "*"
+    }
+
+    actions = [
+      "s3:*",
+    ]
+
+    condition {
+      test = "Bool"
+
+      values = [
+        "false",
+      ]
+
+      variable = "aws:SecureTransport"
+    }
+
+    resources = [
+      "${aws_s3_bucket.assets-bucket.arn}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "attach_secure_transport_policy_to_assets_bucket_s3" {
+  bucket = "${aws_s3_bucket.assets-bucket.bucket}"
+  policy = "${data.aws_iam_policy_document.assets_bucket_policy.json}"
+}
 
 ##############################################################
 # Add custom policy to CCS_Developer_API_Access group and

--- a/terraform/infrastructure/iam_policy.tf
+++ b/terraform/infrastructure/iam_policy.tf
@@ -1,0 +1,10 @@
+resource "aws_iam_account_password_policy" "iam_account_password_policy" {
+  allow_users_to_change_password  = true
+  max_password_age                = 90
+  minimum_password_length         = 10
+  password_reuse_prevention       = 5
+  require_lowercase_characters    = true
+  require_numbers                 = true
+  require_symbols                 = true
+  require_uppercase_characters    = true
+}

--- a/terraform/infrastructure/variables.tf
+++ b/terraform/infrastructure/variables.tf
@@ -269,4 +269,5 @@ locals {
   log_bucket_name = "ccs.${data.aws_caller_identity.current.account_id}.${lower(var.environment_name)}.logs"
   app_api_bucket_name = "ccs.${data.aws_caller_identity.current.account_id}.${lower(var.environment_name)}.app-api-data"
   assets_bucket_name = "${data.aws_caller_identity.current.account_id}-assets"
+  s3_logging_bucket_name = "ccs.${data.aws_caller_identity.current.account_id}.s3.access-logs"
 }


### PR DESCRIPTION
As per the FM ITHC requirements (see FMFR-533 and CLE-3), the following changes need to be implemented via Terraform:
- Add “SecureTransport: False” to the S3 bucket policy for all S3 buckets in a given account
- Enable versioning on all S3 buckets in a given account
- Enable logging on all S3 buckets in a given account, specifying where the logs go (Logging S3 bucket)
- Enable default encryption on all S3 buckets in a given account (Jack’s changes)
- Modify Password Policy - enable password expiration (90 days), prevent password reuse (remember 5 passwords)

This PR implements the above functionality for all required resources, and also captures any resources that weren't previously managed by Terraform.