### PR TITLE
set EBS encryption as default in development branch

### DIFF
--- a/terraform/infrastructure/ebs_encryption.tf
+++ b/terraform/infrastructure/ebs_encryption.tf
@@ -1,0 +1,4 @@
+resource "aws_ebs_encryption_by_default" "cmp_ebs_encryption" {
+  enabled = true
+}
+


### PR DESCRIPTION
Setting EBS encryption to default for DF development branch in compliance with IT health check recommendations