### PR TITLE
Require minimum length to be 14 instead of 10 for sbx

### DIFF
--- a/terraform/infrastructure/iam_policy.tf
+++ b/terraform/infrastructure/iam_policy.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_account_password_policy" "iam_account_password_policy" {
   allow_users_to_change_password = true
   max_password_age               = 90
-  minimum_password_length        = 10
+  minimum_password_length        = 14
   password_reuse_prevention      = 5
   require_lowercase_characters   = true
   require_numbers                = true


### PR DESCRIPTION
Updated minimum password length to 14